### PR TITLE
Fix Bootstrap

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,11 +52,14 @@ for task in ${Tasks}; do
   echo "Compiling $task to ELF..."
   for i in {0..255}
   do
-    "${SRC}"/build/src/sys-driver/c-to-elf-sys "${OUTPUT}"/"${task}"/function"${i}".c "${OUTPUT}"/"${task}"/function-impl.h "${OUTPUT}"/"${task}"/function.h "${SRC}"/build/llvm-project/llvm/lib/clang/18/include/ "${OUTPUT}"/"${task}"/function"${i}".o &
-    running=$(jobs -r | wc -l)
-    if [ "$running" -ge $(("$PARALLEL"-1)) ]
-    then
-      wait -n
+    if test -f "${OUTPUT}"/"${task}"/function"${i}".c; then
+
+      "${SRC}"/build/src/sys-driver/c-to-elf-sys "${OUTPUT}"/"${task}"/function"${i}".c "${OUTPUT}"/"${task}"/function-impl.h "${OUTPUT}"/"${task}"/function.h "${SRC}"/build/llvm-project/llvm/lib/clang/18/include/ "${OUTPUT}"/"${task}"/function"${i}".o &
+      running=$(jobs -r | wc -l)
+      if [ "$running" -ge $(("$PARALLEL"-1)) ]
+      then
+        wait -n
+      fi
     fi
     printf "\r"
     progress_bar "$task" $(("$i"-"$running")) "$running" 256
@@ -76,8 +79,10 @@ for task in ${Tasks}; do
 
   for i in {0..255}
   do
-    LLDSYS+=" "
-    LLDSYS+="${OUTPUT}/${task}/function${i}.o"
+    if test -f "${OUTPUT}"/"${task}"/function"${i}".c; then
+      LLDSYS+=" "
+      LLDSYS+="${OUTPUT}/${task}/function${i}.o"
+    fi
   done
   eval "${LLDSYS}"
 done

--- a/src/serialize/serialize.cc
+++ b/src/serialize/serialize.cc
@@ -139,18 +139,28 @@ int main( int argc, char* argv[] )
 
   size_t index = 0;
   for ( auto file : files ) {
-    std::ofstream fout( refs / ( file + "-elf" ) );
-    fout << base64::encode( elf_names[index] );
-    fout.close();
-    index++;
-  }
-
-  index = 0;
-  for ( auto file : files ) {
     std::ofstream fout( refs / ( file + "-wasm" ) );
     fout << base64::encode( wasm_names[index] );
     fout.close();
     index++;
+  }
+
+  for ( size_t i = 0; i < 4; i++ ) {
+    std::ofstream fout( refs / ( files[i] + "-runnable-tag" ) );
+    fout << base64::encode( runnable_tags[i] );
+    fout.close();
+  }
+
+  {
+    std::ofstream fout ( refs / ( "compile-runnable-tag" ) );
+    fout << base64::encode( runnable_compile_name );
+    fout.close();
+  }
+
+  {
+    std::ofstream fout ( refs / ( "compile-elf" ) );
+    fout << base64::encode( elf_names[4] );
+    fout.close();
   }
 
   std::ofstream st_out( refs / "system-dep-tree" );

--- a/src/wasm2c/initcomposer.cc
+++ b/src/wasm2c/initcomposer.cc
@@ -310,7 +310,7 @@ void InitComposer::write_unsafe_io()
             << state_info_type_name_ << "*)instance);" << endl;
     result_ << "  fixpoint_unsafe_io(index, length, main_mem);" << endl;
   }
-  result_ << "}" << endl;
+  result_ << "}\n" << endl;
 }
 
 void InitComposer::write_get_attached_tree()
@@ -396,7 +396,6 @@ string InitComposer::compose_header()
 
   vector<function> fns = {
     { "__m256i", "create_blob_i32", { "uint32_t" } },
-    { "__m256i", "create_blob_i32", { "uint32_t" } },
     { "__m256i", "create_tag", { "__m256i", "__m256i" } },
     { "__m256i", "create_thunk", { "__m256i" } },
     { "__m256i", "debug_try_evaluate", { "__m256i" } },
@@ -409,9 +408,9 @@ string InitComposer::compose_header()
     { "uint32_t", "get_value_type", { "__m256i" } },
   };
 
-  unordered_map<string, function> fns_map {};
+  vector<pair<string, function>> fns_map {};
   for ( const auto& fn : fns ) {
-    fns_map.insert( std::make_pair( fn.name, fn ) );
+    fns_map.push_back( std::make_pair( fn.name, fn ) );
   }
 
   const auto& imported = inspector_->GetImportedFunctions();

--- a/src/wasm2c/wasm-to-c.cc
+++ b/src/wasm2c/wasm-to-c.cc
@@ -75,8 +75,22 @@ static vector<size_t> consistent_hashing_name_to_output_file_index( vector<Func*
   return result;
 }
 
-tuple<array<string, NUM_OUTPUT>, string, string, optional<string>> wasm_to_c( const void* wasm_source,
-                                                                              size_t source_size )
+string fixpoint_c;
+
+static void stream_finish_callback( function<void( size_t, string )> driver_stream_finish_callback,
+                                    size_t stream_index,
+                                    Stream* stream )
+{
+  if ( stream_index == 0 ) {
+    stream->WriteData( fixpoint_c.data(), fixpoint_c.size() );
+  }
+
+  driver_stream_finish_callback( stream_index, static_cast<MemoryStringStream*>( stream )->ReleaseStringBuf() );
+}
+
+tuple<string, string, optional<string>> wasm_to_c( const void* wasm_source,
+                                                   size_t source_size,
+                                                   function<void( size_t, string )> driver_stream_finish_callback )
 {
   Errors errors;
   Module module;
@@ -112,6 +126,8 @@ tuple<array<string, NUM_OUTPUT>, string, string, optional<string>> wasm_to_c( co
     module.memories[index]->bounds_checked = true;
   }
 
+  fixpoint_c = initcomposer::compose_header( "function", &module, &errors, &inspector );
+
   WriteCOptions write_c_options;
   write_c_options.module_name = "function";
   write_c_options.name_to_output_file_index = bind( consistent_hashing_name_to_output_file_index,
@@ -120,6 +136,8 @@ tuple<array<string, NUM_OUTPUT>, string, string, optional<string>> wasm_to_c( co
                                                     placeholders::_3,
                                                     placeholders::_4,
                                                     parallelism );
+  write_c_options.stream_finish_callback
+    = bind( stream_finish_callback, driver_stream_finish_callback, placeholders::_1, placeholders::_2 );
   WriteC( std::move( c_stream_ptrs ),
           &h_stream,
           &h_impl_stream,
@@ -128,16 +146,8 @@ tuple<array<string, NUM_OUTPUT>, string, string, optional<string>> wasm_to_c( co
           &module,
           write_c_options );
 
-  string fixpoint_c = initcomposer::compose_header( "function", &module, &errors, &inspector );
-  c_streams[0].WriteData( fixpoint_c.data(), fixpoint_c.size() );
-
-  array<string, NUM_OUTPUT> c_outputs;
-  for ( unsigned int i = 0; i < NUM_OUTPUT; i++ ) {
-    c_outputs[i] = c_streams[i].ReleaseStringBuf();
-  }
   string error_string = FormatErrorsToString( errors, Location::Type::Text );
-  return { c_outputs,
-           h_stream.ReleaseStringBuf(),
+  return { h_stream.ReleaseStringBuf(),
            h_impl_stream.ReleaseStringBuf(),
            errors.empty() ? nullopt : make_optional( error_string ) };
 }

--- a/src/wasm2c/wasm-to-c.cc
+++ b/src/wasm2c/wasm-to-c.cc
@@ -39,9 +39,9 @@ static vector<size_t> consistent_hashing_name_to_output_file_index( vector<Func*
   map<string, pair<bool, size_t>> hash_to_index;
 
   // Insert file indexes to the map
-  for ( size_t i = 0; i < num_outputs; i++ ) {
+  for ( uint32_t i = 0; i < num_outputs; i++ ) {
     string hash_key;
-    wabt::sha256( { reinterpret_cast<char*>( &i ), sizeof( size_t ) }, hash_key );
+    wabt::sha256( { reinterpret_cast<char*>( &i ), sizeof( uint32_t ) }, hash_key );
     hash_to_index[hash_key] = { true, i };
   }
 

--- a/src/wasm2c/wasm-to-c.hh
+++ b/src/wasm2c/wasm-to-c.hh
@@ -1,4 +1,5 @@
 #include <array>
+#include <functional>
 #include <optional>
 #include <string>
 #include <tuple>
@@ -6,6 +7,7 @@
 
 #define NUM_OUTPUT 256
 
-std::tuple<std::array<std::string, NUM_OUTPUT>, std::string, std::string, std::optional<std::string>> wasm_to_c(
+std::tuple<std::string, std::string, std::optional<std::string>> wasm_to_c(
   const void* wasm_source,
-  size_t source_size );
+  size_t source_size,
+  std::function<void( size_t, std::string )> driver_stream_finish_callback );


### PR DESCRIPTION
* Pass in stream_finish_callback that create a blob rightaway to decrease wasm-to-c-fix memory usage

* Skip generating empty c file for sys-driver/wasm-to-c

* Fix different `sizeof( size_t )` and Fixpoint api function order across the `fix-driver` and `sys-driver`

This PR gets bootstrap self-hosing in Fixpoint again