### PR TITLE
Swap tag order (fix-project/fix#136)

### DIFF
--- a/src/fix-driver/compile.wat
+++ b/src/fix-driver/compile.wat
@@ -93,7 +93,7 @@
     (call $attach_tree_ro_table_0 (table.get $ro_table_0 (i32.const 2)))
 
     ;; check if the tag was authored by us
-    (call $equality (local.get $compile) (table.get $ro_table_0 (i32.const 1)))
+    (call $equality (local.get $compile) (table.get $ro_table_0 (i32.const 0)))
 
     (if (result externref)
       (then
@@ -102,7 +102,7 @@
 
         ;; zoom into the boot toolchain tree
         ;; this contains: [wasm2c, cc, ld, system_deps, clang_deps, map]
-        (call $attach_tree_ro_table_0 (table.get $ro_table_0 (i32.const 0)))
+        (call $attach_tree_ro_table_0 (table.get $ro_table_0 (i32.const 1)))
         (local.set $wasm2c (table.get $ro_table_0 (i32.const 0)))
         (local.set $cc (table.get $ro_table_0 (i32.const 1)))
         (local.set $ld (table.get $ro_table_0 (i32.const 2)))
@@ -263,7 +263,7 @@
       ;; Attach the Tag
       (call $attach_tree_ro_table_0 (local.get $input))
       ;; check if the tag was authored by us
-      (call $equality (local.get $compile) (table.get $ro_table_0 (i32.const 1)))
+      (call $equality (local.get $compile) (table.get $ro_table_0 (i32.const 0)))
       (if
         (then
           ;; Created by compile
@@ -276,7 +276,7 @@
 
       ;; The tag we created contains a tag created by some step in the process;
       ;; we need to ensure that's an "Okay" tag.
-      (local.set $result (table.get $ro_table_0 (i32.const 0)))
+      (local.set $result (table.get $ro_table_0 (i32.const 1)))
       (call $attach_tree_ro_table_0 (local.get $result))
       (call $equality
         (call $create_blob_rw_mem_4 (i32.const 4))
@@ -287,9 +287,9 @@
         )
         (else
           ;; Not valid, tag the object as Error
-          (call $error_not_runnable (table.get $ro_table_0 (i32.const 0)))
+          (call $error_not_runnable (table.get $ro_table_0 (i32.const 1)))
           (return)))
       ;; Valid, tag the object as Runnable
-      (call $tag_runnable (table.get $ro_table_0 (i32.const 0)))
+      (call $tag_runnable (table.get $ro_table_0 (i32.const 1)))
     )
 )

--- a/src/fix-driver/link-elfs-driver.cc
+++ b/src/fix-driver/link-elfs-driver.cc
@@ -59,8 +59,8 @@ externref fixpoint_apply( externref encode )
     return get_ro_table_0( 2 );
   }
 
-  // Look at the Object
-  attach_tree_ro_table_1( get_ro_table_1( 0 ) );
+  // Look at the Object in the tag
+  attach_tree_ro_table_1( get_ro_table_1( 1 ) );
   std::vector<char*> dep_files;
   std::vector<size_t> dep_file_sizes;
 
@@ -72,8 +72,8 @@ externref fixpoint_apply( externref encode )
       // not okay, return the error message
       return tag;
     }
-    // unwrap the result
-    attach_blob_ro_mem_0(get_ro_table_0(0));
+    // unwrap the result tag
+    attach_blob_ro_mem_0(get_ro_table_0(1));
     char* buffer = (char*)malloc( size_ro_mem_0() + 1 );
     ro_0_to_program_memory( buffer, 0, size_ro_mem_0() );
     buffer[size_ro_mem_0()] = '\0';

--- a/src/fix-driver/map.wat
+++ b/src/fix-driver/map.wat
@@ -37,7 +37,7 @@
         ;; Error
         (return (table.get $ro_table_0 (i32.const 3)))
       ))
-    (call $attach_tree_ro_table_1 (table.get $ro_table_1 (i32.const 0)))
+    (call $attach_tree_ro_table_1 (table.get $ro_table_1 (i32.const 1)))
 
     (local.set $x (table.get $ro_table_1 (i32.const 0)))
 

--- a/src/serialize/serialize.cc
+++ b/src/serialize/serialize.cc
@@ -88,8 +88,8 @@ int main( int argc, char* argv[] )
   vector<Handle> runnable_tags;
   for ( size_t i = 0; i < 4; i++ ) {
     vector<Handle> runnable_tag;
-    runnable_tag.push_back( elf_names[i] );
     runnable_tag.push_back( elf_names[4] );
+    runnable_tag.push_back( elf_names[i] );
     runnable_tag.push_back( Handle( "Runnable" ) );
     runnable_tags.push_back( serialize_tag( objects, runnable_tag ) );
   }
@@ -112,8 +112,8 @@ int main( int argc, char* argv[] )
 
   // Tag compile_tool_tree bootstrap
   vector<Handle> compile_tool_tree_tag;
-  compile_tool_tree_tag.push_back( compile_tool_tree_name );
   compile_tool_tree_tag.push_back( elf_names[4] );
+  compile_tool_tree_tag.push_back( compile_tool_tree_name );
   compile_tool_tree_tag.push_back( Handle( "Bootstrap" ) );
   Handle compile_tool_tree_tag_name = serialize_tag( objects, compile_tool_tree_tag );
 
@@ -122,7 +122,7 @@ int main( int argc, char* argv[] )
   compile_encode.push_back( Handle( "compile" ) );
   compile_encode.push_back( runnable_compile_name );
   compile_encode.push_back( compile_tool_tree_tag_name );
-  Handle compile_encode_name = serialize_tag( objects, compile_encode );
+  Handle compile_encode_name = serialize_tree( objects, compile_encode );
 
   std::ofstream compile_tool_out( refs / "compile-encode" );
   compile_tool_out << base16::encode( compile_encode_name );


### PR DESCRIPTION
For fix-project/fix#136
Swaps tag access order where used
Also fixes `compile_encode` to use tree serialization instead of tag serialization 